### PR TITLE
fix human buildables appearing offset when stacked

### DIFF
--- a/src/cgame/cg_buildable.c
+++ b/src/cgame/cg_buildable.c
@@ -645,19 +645,19 @@ static void CG_PositionAndOrientateBuildable(const vec3_t angles,
 	VectorMA(inOrigin, 1.0f, normal, start);
 	CG_CapTrace(&tr, start, mins, maxs, end, skipNumber, MASK_PLAYERSOLID);
 
-	CG_Trace( &box_tr, start, mins, maxs, end, skipNumber,
-            MASK_PLAYERSOLID );
+	CG_Trace(&box_tr, start, mins, maxs, end, skipNumber,
+					 MASK_PLAYERSOLID);
 
-  mag = Distance( tr.endpos, box_tr.endpos );
+	mag = Distance(tr.endpos, box_tr.endpos);
 
-  fraction = tr.fraction;
+ 	fraction = tr.fraction;
 
-  // this is either too far off of the bbox to be useful for gameplay purposes
-  // or the model is positioned in thin air anyways.
+	// this is either too far off of the bbox to be useful for gameplay purposes
+	// or the model is positioned in thin air anyways.
 	// cu-kai: don't fix alien buildables here, this breaks them more.
 	//				 TODO: fix alien buildables properly later
-  if( alien == qfalse && ( mag > 10.0f || tr.fraction == 1.0f ) )
-    fraction = box_tr.fraction;
+	if(!alien && (mag > 10.0f || tr.fraction == 1.0f))
+		fraction = box_tr.fraction;
 
 	VectorMA(inOrigin, fraction * -TRACE_DEPTH, normal, outOrigin);
 }
@@ -688,7 +688,7 @@ void CG_GhostBuildable(buildable_t buildable)
 	CG_PositionAndOrientateBuildable(ps->viewangles, entity_origin,
 					 tr.plane.normal, ps->clientNum, mins,
 					 maxs, ent.axis, ent.origin, 
-					 BG_FindTeamForBuildable(buildable) == BIT_ALIENS ? qtrue : qfalse );
+					 BG_FindTeamForBuildable(buildable) == BIT_ALIENS);
 
 	//offset on the Z axis if required
 	VectorMA(ent.origin, BG_FindZOffsetForBuildable(buildable),
@@ -1238,7 +1238,7 @@ void CG_Buildable(centity_t * cent)
 		CG_PositionAndOrientateBuildable(angles, ent.origin, surfNormal,
 						 es->number, mins, maxs,
 						 ent.axis, ent.origin, 
-						 BG_FindTeamForBuildable(es->modelindex) == BIT_ALIENS ? qtrue : qfalse);
+						 BG_FindTeamForBuildable(es->modelindex) == BIT_ALIENS);
 
 	//offset on the Z axis if required
 	VectorMA(ent.origin, BG_FindZOffsetForBuildable(es->modelindex),

--- a/src/cgame/cg_buildable.c
+++ b/src/cgame/cg_buildable.c
@@ -620,7 +620,7 @@ static void CG_PositionAndOrientateBuildable(const vec3_t angles,
 					     const vec3_t maxs,
 					     vec3_t outAxis[3],
 					     vec3_t outOrigin,
-					     qboolean alien)
+					     buildable_t buildable)
 {
 	vec3_t forward, start, end;
 	trace_t tr, box_tr;
@@ -656,7 +656,7 @@ static void CG_PositionAndOrientateBuildable(const vec3_t angles,
 	// or the model is positioned in thin air anyways.
 	// cu-kai: don't fix alien buildables here, this breaks them more.
 	//				 TODO: fix alien buildables properly later
-	if(!alien && (mag > 10.0f || tr.fraction == 1.0f))
+	if (BG_FindTeamForBuildable(buildable) == BIT_HUMANS && (mag > 10.0f || tr.fraction == 1.0f))
 		fraction = box_tr.fraction;
 
 	VectorMA(inOrigin, fraction * -TRACE_DEPTH, normal, outOrigin);
@@ -687,8 +687,7 @@ void CG_GhostBuildable(buildable_t buildable)
 
 	CG_PositionAndOrientateBuildable(ps->viewangles, entity_origin,
 					 tr.plane.normal, ps->clientNum, mins,
-					 maxs, ent.axis, ent.origin, 
-					 BG_FindTeamForBuildable(buildable) == BIT_ALIENS);
+					 maxs, ent.axis, ent.origin, buildable);
 
 	//offset on the Z axis if required
 	VectorMA(ent.origin, BG_FindZOffsetForBuildable(buildable),
@@ -1202,6 +1201,7 @@ void CG_Buildable(centity_t * cent)
 {
 	refEntity_t ent;
 	entityState_t *es = &cent->currentState;
+	buildable_t buildable = cent->currentState.modelindex;
 	vec3_t angles;
 	vec3_t surfNormal, xNormal, mins, maxs;
 	vec3_t refNormal = { 0.0f, 0.0f, 1.0f };
@@ -1237,8 +1237,7 @@ void CG_Buildable(centity_t * cent)
 	if (es->pos.trType == TR_STATIONARY)
 		CG_PositionAndOrientateBuildable(angles, ent.origin, surfNormal,
 						 es->number, mins, maxs,
-						 ent.axis, ent.origin, 
-						 BG_FindTeamForBuildable(es->modelindex) == BIT_ALIENS);
+						 ent.axis, ent.origin, buildable);
 
 	//offset on the Z axis if required
 	VectorMA(ent.origin, BG_FindZOffsetForBuildable(es->modelindex),


### PR DESCRIPTION
this should fix people being able to abuse the stackable buildings in the human base to make them appear below their hitbox